### PR TITLE
Added GitHub action to run pester tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,5 +9,5 @@ jobs:
 
     steps:
       - name: Build
-        run: .\Build\Snow.SnowAutomationPlatform.ServiceNow.Integration.BUILD.ps1
+        run: ls
         shell: powershell

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
+    - name: Import required modules
+      run: Install-Module -Name InvokeBuild, PlatyPS, PowerShellGet, Pester -SkipPublisherCheck -Force
+      shell: powershell
     - name: Build
-      run: .\Build\Snow.SnowAutomationPlatform.ServiceNow.Integration.BUILD.ps1
+      run: |
+        $ErrorActionPreference = 'Stop'
+        invoke-build -File .\Build\Snow.SnowAutomationPlatform.ServiceNow.Integration.BUILD.ps1
       shell: powershell

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,5 +9,6 @@ jobs:
 
     steps:
       - name: Build
-        run: .\Build\Snow.SnowAutomationPlatform.ServiceNow.Integration.BUILD.ps1
+        run: |
+          .\Build\Snow.SnowAutomationPlatform.ServiceNow.Integration.BUILD.ps1
         shell: powershell

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,6 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - name: Display the path
-        run: echo ${env:PATH}
+      - name: Build
+        run: .\Build\Snow.SnowAutomationPlatform.ServiceNow.Integration.BUILD.ps1
         shell: powershell

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Import required modules
       run: Install-Module -Name InvokeBuild, PlatyPS, PowerShellGet, Pester -SkipPublisherCheck -Force
       shell: powershell
-    - name: Build
+    - name: Run Pester tests
       run: |
         $ErrorActionPreference = 'Stop'
         invoke-build -File .\Build\Snow.SnowAutomationPlatform.ServiceNow.Integration.BUILD.ps1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - name: Build
-        run: |
-          .\Build\Snow.SnowAutomationPlatform.ServiceNow.Integration.BUILD.ps1
-        shell: powershell
+    - uses: actions/checkout@v1
+    - name: Build
+      run: .\Build\Snow.SnowAutomationPlatform.ServiceNow.Integration.BUILD.ps1
+      shell: powershell

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,5 +9,5 @@ jobs:
 
     steps:
       - name: Build
-        run: ls
+        run: .\Build\Snow.SnowAutomationPlatform.ServiceNow.Integration.BUILD.ps1
         shell: powershell

--- a/Build/Snow.SnowAutomationPlatform.ServiceNow.Integration.BUILD.ps1
+++ b/Build/Snow.SnowAutomationPlatform.ServiceNow.Integration.BUILD.ps1
@@ -54,6 +54,7 @@ task CompilePSM {
         $UpdateManifestParam['AliasesToExport'] = $PublicAlias
     }
 
+    # github actions does not have version yet, but I will heep this line here for reference
     $UpdateManifestParam['ModuleVersion'] = $env:APPVEYOR_BUILD_VERSION
 
     $ExportStrings = 'Export-ModuleMember',$PublicFunctionParam,$PublicAliasParam | Where-Object {-Not [string]::IsNullOrWhiteSpace($_)}
@@ -68,6 +69,7 @@ task MakeHelp -if (Test-Path -Path "$BuildRoot\docs") {
     New-ExternalHelp -Path ".\docs" -OutputPath "$BuildRoot\bin\$ModuleName\en-US"
 }
 
-task . Clean, TestCode, Build
+task . Clean, TestCode #, Build
 
-task Build CopyFiles, CompilePSM, MakeHelp
+# removing build as this is dependent on some appveryor features which is not yet implemented in github actions
+# task Build CopyFiles, CompilePSM, MakeHelp


### PR DESCRIPTION
Added GitHub action to run pester tests. Modified build script to work with GitHub actions instead of appveyor. Now we are not building artifacts. That could be added in the future.